### PR TITLE
Add a hover state to affected resources displayed in the list

### DIFF
--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -2,7 +2,7 @@
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
 // @downloadURL  https://raw.githubusercontent.com/MakroCZ/IdleLoops-Predictor/master/idleloops-predictor.user.js
-// @version      2.2.4
+// @version      2.2.5
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://lloyd-delacroix.github.io/omsi-loops/
@@ -465,7 +465,7 @@ const Koviko = {
       .nextActionContainer[style~='flex;'] {display: grid!important;}
       .nextActionContainer > div:first-child { width: 70px; }
       .nextActionContainer > div:nth-child(2) { width: 120px; text-align: right; grid-area: c }
-      .koviko.valid { grid-area: b;pointer-events:auto }
+      .koviko.valid, .koviko.invalid { grid-area: b;pointer-events:auto }
       #nextActionsList{height:100%!important; overflow-y:scroll;}
       #curActionsListContainer{width:120px!important; z-index: 100;}
       #nextActionsList:hover{margin-left:-40%;padding-left:40%}

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -470,6 +470,7 @@ const Koviko = {
       #curActionsListContainer{width:120px!important; z-index: 100;}
       #nextActionsList:hover{margin-left:-40%;padding-left:40%}
       #actionList>div:nth-child(2){left: 53px !important}
+      #nextActionsList.disabled ul.koviko{display:none;}
       .nextActionContainer:nth-child(1n+9) .showthis {bottom: 5px; top: unset;}
       span.koviko{font-weight:bold;color:#8293ff;}
       div.koviko{top:-5px;left:auto;right:100%}

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -465,7 +465,7 @@ const Koviko = {
       .nextActionContainer[style~='flex;'] {display: grid!important;}
       .nextActionContainer > div:first-child { width: 70px; }
       .nextActionContainer > div:nth-child(2) { width: 120px; text-align: right; grid-area: c }
-      .koviko.valid { grid-area: b; }
+      .koviko.valid { grid-area: b;pointer-events:auto }
       #nextActionsList{height:100%!important; overflow-y:scroll;}
       #curActionsListContainer{width:120px!important; z-index: 100;}
       #nextActionsList:hover{margin-left:-40%;padding-left:40%}
@@ -1877,7 +1877,7 @@ const Koviko = {
       tooltip+= '<tr><td><b>TIME</b></td><td>' + precision3(resources.totalTicks/50, 1) + '</td><td>(+' + precision3(resources.actionTicks/50, 1) + ')</td></tr>';
 
       var Affec = affected.map(name => {
-        if ( resources[name] != 0 ) return ('<li class='+name+'>'+resources[name].toLocaleString('en', {useGrouping:true})+'</li>');
+        if ( resources[name] != 0 ) return ('<li class='+name+' title='+name.charAt(0).toUpperCase() + name.slice(1)+'>'+resources[name].toLocaleString('en', {useGrouping:true})+'</li>');
         else return "";
       }).join('');
       return \`<ul class='koviko \${isValid}'>\` + Affec + \`</ul><div class='koviko showthis'><table>\${tooltip || '<b>N/A</b>'}</table></div>\`;


### PR DESCRIPTION
Presumably there's a way to have it be more human readable rather than using the internal name

It's probably worth building a lookup table to be able to display proper names, but I don't know enough about endgame content to know what should go in it and capitalizing the first letter was enough of a hack to make it feel more proper to me.